### PR TITLE
Fix: setFileFilter() should not be called statically

### DIFF
--- a/src/FileUploadControl.php
+++ b/src/FileUploadControl.php
@@ -266,7 +266,7 @@ class FileUploadControl extends \Nette\Forms\Controls\UploadControl {
 	 * Nastaví třídu pro filtrování nahrávaných souborů.
 	 * @param string $fileFilter
 	 */
-	public function setFileFilter($fileFilter) {
+	public static function setFileFilter($fileFilter) {
 		self::$fileFilter = $fileFilter;
 	}
 

--- a/src/FileUploadControl.php
+++ b/src/FileUploadControl.php
@@ -125,7 +125,7 @@ class FileUploadControl extends \Nette\Forms\Controls\UploadControl {
 	 * Třída pro filtrování nahrávaných souborů.
 	 * @var string
 	 */
-	private $fileFilter;
+	private static $fileFilter;
 
 	/**
 	 * @var string
@@ -259,7 +259,7 @@ class FileUploadControl extends \Nette\Forms\Controls\UploadControl {
 	 * @internal
 	 */
 	public function getFileFilter() {
-		return $this->fileFilter;
+		return self::$fileFilter;
 	}
 
 	/**
@@ -267,7 +267,7 @@ class FileUploadControl extends \Nette\Forms\Controls\UploadControl {
 	 * @param string $fileFilter
 	 */
 	public function setFileFilter($fileFilter) {
-		$this->fileFilter = $fileFilter;
+		self::$fileFilter = $fileFilter;
 	}
 
 	/**


### PR DESCRIPTION
Setup Zet\FileUpload\FileUploadControl::setFileFilter(\Zet\FileUpload\FileUploadControl::FILTER_IMAGES) in bootstrap ends by error:
Non-static method Zet\FileUpload\FileUploadControl::setFileFilter() should not be called statically
