### PR TITLE
JS ready místo jQuery

### DIFF
--- a/src/Template/javascript.latte
+++ b/src/Template/javascript.latte
@@ -1,5 +1,5 @@
 <script>
-$(function() {
+document.addEventListener("DOMContentLoaded", function(event) {
 	// -----------------------------------------------------------------------
 	// Control sys variables
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
Pokud jsou všechny JS včetně jQuery přikládány na konci dokumentu, je možná lepší místo $().ready použít čistý JS.
