### PR TITLE
Oprava Nette\Object

### DIFF
--- a/src/Filter/BaseFilter.php
+++ b/src/Filter/BaseFilter.php
@@ -2,13 +2,16 @@
 
 namespace Zet\FileUpload\Filter;
 
+use Nette\SmartObject;
+
 /**
  * Class BaseFilter
  *
  * @author  Zechy <email@zechy.cz>
  * @package Zet\FileUpload\Filter
  */
-abstract class BaseFilter extends \Nette\Object implements IMimeTypeFilter {
+abstract class BaseFilter implements IMimeTypeFilter {
+	use SmartObject;
 	
 	/**
 	 * Vrátí seznam povolených typů souborů s jejich typickou koncovkou.

--- a/src/Model/BaseUploadModel.php
+++ b/src/Model/BaseUploadModel.php
@@ -2,7 +2,7 @@
 
 namespace Zet\FileUpload\Model;
 
-use Tracy\Debugger;
+use Nette\SmartObject;
 
 /**
  * Class BaseUploadModel
@@ -10,7 +10,8 @@ use Tracy\Debugger;
  * @author  Zechy <email@zechy.cz>
  * @package Zet\FileUpload\Model
  */
-class BaseUploadModel extends \Nette\Object implements IUploadModel {
+class BaseUploadModel implements IUploadModel {
+	use SmartObject;
 	
 	/**
 	 * Uložení nahraného souboru.

--- a/src/Model/DefaultFile.php
+++ b/src/Model/DefaultFile.php
@@ -2,8 +2,7 @@
 
 namespace Zet\FileUpload\Model;
 
-use Nette\Object;
-use Nette\Utils\Html;
+use Nette\SmartObject;
 
 /**
  * Class DefaultFile
@@ -12,7 +11,8 @@ use Nette\Utils\Html;
  * @author  Zechy <email@zechy.cz>
  * @package Zet\FileUpload\Model
  */
-class DefaultFile extends Object {
+class DefaultFile {
+	use SmartObject;
 	
 	/**
 	 * Callback pro smazání výchozího souboru s parametry (mixed $identifier).

--- a/src/Template/JavascriptBuilder.php
+++ b/src/Template/JavascriptBuilder.php
@@ -2,7 +2,7 @@
 
 namespace Zet\FileUpload\Template;
 
-use Nette\Object;
+use Nette\SmartObject;
 use Tracy\Debugger;
 use Zet\FileUpload\Model\UploadController;
 use Zet\FileUpload\Template\Renderer\BaseRenderer;
@@ -13,7 +13,8 @@ use Zet\FileUpload\Template\Renderer\BaseRenderer;
  * @author  Zechy <email@zechy.cz>
  * @package Zet\FileUpload
  */
-class JavascriptBuilder extends Object {
+class JavascriptBuilder {
+	use SmartObject;
 	
 	/**
 	 * @var \Nette\Application\UI\ITemplate
@@ -41,15 +42,15 @@ class JavascriptBuilder extends Object {
 	private $renderer;
 	
 	/**
-	 * @var \Zet\FileUpload\Model\UploadController
+	 * @var UploadController
 	 */
 	private $controller;
 	
 	/**
 	 * JavascriptBuilder constructor.
 	 *
-	 * @param \Zet\FileUpload\Template\Renderer\BaseRenderer $renderer
-	 * @param \Zet\FileUpload\Model\UploadController         $controller
+	 * @param BaseRenderer $renderer
+	 * @param UploadController         $controller
 	 */
 	public function __construct(
 		BaseRenderer $renderer,
@@ -99,7 +100,7 @@ class JavascriptBuilder extends Object {
 		$this->template->maxFileSize = $this->controller->getUploadControl()->getMaxFileSize();
 		/** @noinspection PhpInternalEntityUsedInspection */
 		$this->template->fileSizeString = $this->controller->getUploadControl()->getFileSizeString();
-		$this->template->productionMode = \Tracy\Debugger::$productionMode;
+		$this->template->productionMode = Debugger::$productionMode;
 		/** @noinspection PhpInternalEntityUsedInspection */
 		$this->template->token = $this->controller->getUploadControl()->getToken();
 		$this->template->params = json_encode($this->controller->getUploadControl()->getParams());

--- a/src/Template/Renderer/BaseRenderer.php
+++ b/src/Template/Renderer/BaseRenderer.php
@@ -3,7 +3,7 @@
 namespace Zet\FileUpload\Template\Renderer;
 
 use Nette\Localization\ITranslator;
-use Nette\Object;
+use Nette\SmartObject;
 use Nette\Utils\Html;
 use Zet\FileUpload\FileUploadControl;
 
@@ -13,7 +13,8 @@ use Zet\FileUpload\FileUploadControl;
  * @author  Zechy <email@zechy.cz>
  * @package Zet\FileUpload\Template\Renderer
  */
-abstract class BaseRenderer extends Object implements IUploadRenderer {
+abstract class BaseRenderer implements IUploadRenderer {
+	use SmartObject;
 	
 	/**
 	 * ID template ve tvaru: HtmlId-ElementType
@@ -55,20 +56,20 @@ abstract class BaseRenderer extends Object implements IUploadRenderer {
 	];
 	
 	/**
-	 * @var \Zet\FileUpload\FileUploadControl
+	 * @var FileUploadControl
 	 */
 	protected $fileUploadControl;
 	
 	/**
-	 * @var \Nette\Localization\ITranslator|NULL
+	 * @var ITranslator|NULL
 	 */
 	protected $translator;
 	
 	/**
 	 * BaseRenderer constructor.
 	 *
-	 * @param \Zet\FileUpload\FileUploadControl    $fileUploadControl
-	 * @param \Nette\Localization\ITranslator|NULL $translator
+	 * @param FileUploadControl    $fileUploadControl
+	 * @param ITranslator|NULL $translator
 	 */
 	public function __construct(
 		FileUploadControl $fileUploadControl,
@@ -112,7 +113,7 @@ abstract class BaseRenderer extends Object implements IUploadRenderer {
 	}
 	
 	/**
-	 * @return \Nette\Utils\Html[]
+	 * @return Html[]
 	 */
 	public function getElements() {
 		return $this->elements;
@@ -121,21 +122,21 @@ abstract class BaseRenderer extends Object implements IUploadRenderer {
 	/**
 	 * Sestavení výchozí šablony uploaderu.
 	 *
-	 * @return \Nette\Utils\Html
+	 * @return Html
 	 */
 	abstract public function buildDefaultTemplate();
 	
 	/**
 	 * Sestavení šablony pro vkládání nových souborů.
 	 *
-	 * @return \Nette\Utils\Html
+	 * @return Html
 	 */
 	abstract public function buildFileContainerTemplate();
 	
 	/**
 	 * Sestavení šablony pro soubor, u kterého vznikla chyba.
 	 *
-	 * @return \Nette\Utils\Html
+	 * @return Html
 	 */
 	abstract public function buildFileError();
 }

--- a/src/Template/Renderer/Bootstrap3Renderer.php
+++ b/src/Template/Renderer/Bootstrap3Renderer.php
@@ -2,7 +2,6 @@
 
 namespace Zet\FileUpload\Template\Renderer;
 
-use Nette\Object;
 use Nette\Utils\Html;
 
 /**
@@ -23,7 +22,7 @@ class Bootstrap3Renderer extends BaseRenderer {
 	/**
 	 * Sestavení výchozí šablony uploaderu.
 	 *
-	 * @return \Nette\Utils\Html
+	 * @return Html
 	 */
 	public function buildDefaultTemplate() {
 		$customContainer = Html::el("div");
@@ -74,7 +73,7 @@ class Bootstrap3Renderer extends BaseRenderer {
 	/**
 	 * Sestavení šablony pro vkládání nových souborů.
 	 *
-	 * @return \Nette\Utils\Html
+	 * @return Html
 	 */
 	public function buildFileContainerTemplate() {
 		$tr = Html::el("tr");
@@ -109,7 +108,7 @@ class Bootstrap3Renderer extends BaseRenderer {
 	/**
 	 * Sestavení šablony pro soubor, u kterého vznikla chyba.
 	 *
-	 * @return \Nette\Utils\Html
+	 * @return Html
 	 */
 	public function buildFileError() {
 		$tr = Html::el("tr class='danger'");

--- a/src/Template/Renderer/Bootstrap4Renderer.php
+++ b/src/Template/Renderer/Bootstrap4Renderer.php
@@ -22,7 +22,7 @@ class Bootstrap4Renderer extends BaseRenderer {
 	/**
 	 * Sestavení výchozí šablony uploaderu.
 	 *
-	 * @return \Nette\Utils\Html
+	 * @return Html
 	 */
 	public function buildDefaultTemplate() {
 		$customContainer = Html::el("div");
@@ -68,7 +68,7 @@ class Bootstrap4Renderer extends BaseRenderer {
 	/**
 	 * Sestavení šablony pro vkládání nových souborů.
 	 *
-	 * @return \Nette\Utils\Html
+	 * @return Html
 	 */
 	public function buildFileContainerTemplate() {
 		$tr = Html::el("tr");
@@ -104,7 +104,7 @@ class Bootstrap4Renderer extends BaseRenderer {
 	/**
 	 * Sestavení šablony pro soubor, u kterého vznikla chyba.
 	 *
-	 * @return \Nette\Utils\Html
+	 * @return Html
 	 */
 	public function buildFileError() {
 		$tr = Html::el("tr class='bg-danger text-light'");

--- a/src/Template/Renderer/Html5Renderer.php
+++ b/src/Template/Renderer/Html5Renderer.php
@@ -119,7 +119,7 @@ class Html5Renderer extends BaseRenderer {
 	
 	/**
 	 * Sestavení šablony pro soubor, u kterého vznikla chyba.
-	 * @return \Nette\Utils\Html
+	 * @return Html
 	 */
 	public function buildFileError() {
 		$tr = Html::el("tr style='background-color: #ffb6c1'");

--- a/src/Template/Renderer/IUploadRenderer.php
+++ b/src/Template/Renderer/IUploadRenderer.php
@@ -2,6 +2,8 @@
 
 namespace Zet\FileUpload\Template\Renderer;
 
+use Nette\Utils\Html;
+
 /**
  * Interface IUploadRenderer
  *
@@ -13,21 +15,21 @@ interface IUploadRenderer {
 	/**
 	 * Sestavení výchozí šablony uploaderu.
 	 *
-	 * @return \Nette\Utils\Html
+	 * @return Html
 	 */
 	public function buildDefaultTemplate();
 	
 	/**
 	 * Sestavení šablony pro vkládání nových souborů.
 	 *
-	 * @return \Nette\Utils\Html
+	 * @return Html
 	 */
 	public function buildFileContainerTemplate();
 	
 	/**
 	 * Sestavení šablony pro soubor, u kterého vznikla chyba.
 	 *
-	 * @return \Nette\Utils\Html
+	 * @return Html
 	 */
 	public function buildFileError();
 }


### PR DESCRIPTION
V Nette 2.4 je Nette\Object [deprecated](https://doc.nette.org/cs/2.4/migration-2-4#toc-nette-smartobject). Pull request jej nahrazuje za Nette\SmartObject.
